### PR TITLE
Added generator for validator class and attached it to the repository

### DIFF
--- a/src/Prettus/Repository/Generators/Commands/EntityCommand.php
+++ b/src/Prettus/Repository/Generators/Commands/EntityCommand.php
@@ -36,12 +36,6 @@ class EntityCommand extends Command
      */
     public function fire()
     {
-        $this->call('make:repository', [
-            'name'       => $this->argument('name'),
-            '--fillable' => $this->option('fillable'),
-            '--rules'    => $this->option('rules'),
-            '--force'    => $this->option('force')
-        ]);
 
         if ($this->confirm('Would you like to create a Presenter? [y|N]')) {
             $this->call('make:presenter', [
@@ -50,13 +44,26 @@ class EntityCommand extends Command
             ]);
         }
 
-        if ($this->confirm('Would you like to create a Validator? [y|N]')) {
+        $validator = $this->option('validator');
+        if (is_null($validator) && $this->confirm('Would you like to create a Validator? [y|N]')) {
+            $validator = 'yes';
+        }
+
+        if ($validator == 'yes') {
             $this->call('make:validator', [
                 'name'    => $this->argument('name'),
                 '--rules' => $this->option('rules'),
                 '--force' => $this->option('force'),
             ]);
         }
+
+        $this->call('make:repository', [
+            'name'        => $this->argument('name'),
+            '--fillable'  => $this->option('fillable'),
+            '--rules'     => $this->option('rules'),
+            '--validator' => $validator,
+            '--force'     => $this->option('force')
+        ]);
     }
 
 
@@ -83,6 +90,7 @@ class EntityCommand extends Command
         return [
             [ 'fillable', null, InputOption::VALUE_OPTIONAL, 'The fillable attributes.', null ],
             [ 'rules', null, InputOption::VALUE_OPTIONAL, 'The rules of validation attributes.', null ],
+            [ 'validator', null, InputOption::VALUE_OPTIONAL, 'Adds validator reference to the repository.', null ],
             [ 'force', 'f', InputOption::VALUE_NONE, 'Force the creation if file already exists.', null ]
         ];
     }

--- a/src/Prettus/Repository/Generators/Commands/EntityCommand.php
+++ b/src/Prettus/Repository/Generators/Commands/EntityCommand.php
@@ -28,6 +28,7 @@ class EntityCommand extends Command
      */
     protected $generators = null;
 
+
     /**
      * Execute the command.
      *
@@ -48,7 +49,16 @@ class EntityCommand extends Command
                 '--force' => $this->option('force'),
             ]);
         }
+
+        if ($this->confirm('Would you like to create a Validator? [y|N]')) {
+            $this->call('make:validator', [
+                'name'    => $this->argument('name'),
+                '--rules' => $this->option('rules'),
+                '--force' => $this->option('force'),
+            ]);
+        }
     }
+
 
     /**
      * The array of command arguments.
@@ -58,9 +68,10 @@ class EntityCommand extends Command
     public function getArguments()
     {
         return [
-            ['name', InputArgument::REQUIRED, 'The name of class being generated.', null],
+            [ 'name', InputArgument::REQUIRED, 'The name of class being generated.', null ],
         ];
     }
+
 
     /**
      * The array of command options.
@@ -70,9 +81,9 @@ class EntityCommand extends Command
     public function getOptions()
     {
         return [
-            ['fillable', null, InputOption::VALUE_OPTIONAL, 'The fillable attributes.', null],
-            ['rules', null, InputOption::VALUE_OPTIONAL, 'The rules of validation attributes.', null],
-            ['force', 'f', InputOption::VALUE_NONE, 'Force the creation if file already exists.', null]
+            [ 'fillable', null, InputOption::VALUE_OPTIONAL, 'The fillable attributes.', null ],
+            [ 'rules', null, InputOption::VALUE_OPTIONAL, 'The rules of validation attributes.', null ],
+            [ 'force', 'f', InputOption::VALUE_NONE, 'Force the creation if file already exists.', null ]
         ];
     }
 }

--- a/src/Prettus/Repository/Generators/Commands/RepositoryCommand.php
+++ b/src/Prettus/Repository/Generators/Commands/RepositoryCommand.php
@@ -26,11 +26,11 @@ class RepositoryCommand extends Command
      */
     protected $description = 'Create a new repository.';
 
-
     /**
      * @var Collection
      */
-    protected $generators  = null;
+    protected $generators = null;
+
 
     /**
      * Execute the command.
@@ -42,30 +42,30 @@ class RepositoryCommand extends Command
         $this->generators = new Collection();
 
         $modelGenerator = new ModelGenerator([
-            'name'      => $this->argument('name'),
-            'fillable'  => $this->option('fillable'),
-            'force'     => $this->option('force')
+            'name'     => $this->argument('name'),
+            'fillable' => $this->option('fillable'),
+            'force'    => $this->option('force')
         ]);
 
         $this->generators->push($modelGenerator);
 
         $this->generators->push(new RepositoryInterfaceGenerator([
-            'name'      => $this->argument('name'),
-            'force'     => $this->option('force'),
+            'name'  => $this->argument('name'),
+            'force' => $this->option('force'),
         ]));
 
-        $model = $modelGenerator->getRootNamespace().'\\'.$modelGenerator->getName();
-        $model = str_replace(["\\",'/'],'\\', $model);
+        $model = $modelGenerator->getRootNamespace() . '\\' . $modelGenerator->getName();
+        $model = str_replace([ "\\", '/' ], '\\', $model);
 
         $this->generators->push(new RepositoryEloquentGenerator([
-            'name'      => $this->argument('name'),
-            'rules'     => $this->option('rules'),
-            'force'     => $this->option('force'),
-            'model'     => $model
+            'name'  => $this->argument('name'),
+            'rules' => $this->option('rules'),
+            'validator' => $this->option('validator'),
+            'force' => $this->option('force'),
+            'model' => $model
         ]));
 
-
-        foreach ( $this->generators as $generator) {
+        foreach ($this->generators as $generator) {
             $generator->run();
         }
 
@@ -81,9 +81,11 @@ class RepositoryCommand extends Command
     public function getArguments()
     {
         return [
-            ['name', InputArgument::REQUIRED, 'The name of class being generated.', null],
+            [ 'name', InputArgument::REQUIRED, 'The name of class being generated.', null ],
         ];
     }
+
+
     /**
      * The array of command options.
      *
@@ -92,9 +94,10 @@ class RepositoryCommand extends Command
     public function getOptions()
     {
         return [
-            ['fillable', null, InputOption::VALUE_OPTIONAL, 'The fillable attributes.', null],
-            ['rules', null, InputOption::VALUE_OPTIONAL, 'The rules of validation attributes.', null],
-            ['force', 'f', InputOption::VALUE_NONE, 'Force the creation if file already exists.', null]
+            [ 'fillable', null, InputOption::VALUE_OPTIONAL, 'The fillable attributes.', null ],
+            [ 'rules', null, InputOption::VALUE_OPTIONAL, 'The rules of validation attributes.', null ],
+            [ 'validator', null, InputOption::VALUE_OPTIONAL, 'Adds validator reference to the repository.', null ],
+            [ 'force', 'f', InputOption::VALUE_NONE, 'Force the creation if file already exists.', null ]
         ];
     }
 }

--- a/src/Prettus/Repository/Generators/Commands/ValidatorCommand.php
+++ b/src/Prettus/Repository/Generators/Commands/ValidatorCommand.php
@@ -1,0 +1,69 @@
+<?php
+namespace Prettus\Repository\Generators\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Collection;
+use Prettus\Repository\Generators\ValidatorGenerator;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputOption;
+
+class ValidatorCommand extends Command
+{
+
+    /**
+     * The name of command.
+     *
+     * @var string
+     */
+    protected $name = 'make:validator';
+
+    /**
+     * The description of command.
+     *
+     * @var string
+     */
+    protected $description = 'Create a new validator.';
+
+
+    /**
+     * Execute the command.
+     *
+     * @return void
+     */
+    public function fire()
+    {
+        (new ValidatorGenerator([
+            'name'  => $this->argument('name'),
+            'rules' => $this->option('rules'),
+            'force' => $this->option('force'),
+        ]))->run();
+        $this->info("Validator created successfully.");
+    }
+
+
+    /**
+     * The array of command arguments.
+     *
+     * @return array
+     */
+    public function getArguments()
+    {
+        return [
+            [ 'name', InputArgument::REQUIRED, 'The name of model for which the validator is being generated.', null ],
+        ];
+    }
+
+
+    /**
+     * The array of command options.
+     *
+     * @return array
+     */
+    public function getOptions()
+    {
+        return [
+            [ 'rules', null, InputOption::VALUE_OPTIONAL, 'The rules of validation attributes.', null ],
+            [ 'force', 'f', InputOption::VALUE_NONE, 'Force the creation if file already exists.', null ],
+        ];
+    }
+}

--- a/src/Prettus/Repository/Generators/Generator.php
+++ b/src/Prettus/Repository/Generators/Generator.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Str;
 
 abstract class Generator
 {
+
     use AppNamespaceDetectorTrait;
 
     /**
@@ -31,16 +32,18 @@ abstract class Generator
      */
     protected $stub;
 
+
     /**
      * Create new instance of this class.
      *
      * @param array $options
      */
-    public function __construct(array $options = array())
+    public function __construct(array $options = [ ])
     {
         $this->filesystem = new Filesystem;
-        $this->options = $options;
+        $this->options    = $options;
     }
+
 
     /**
      * Get the filesystem instance.
@@ -52,17 +55,21 @@ abstract class Generator
         return $this->filesystem;
     }
 
+
     /**
      * Set the filesystem instance.
      *
      * @param \Illuminate\Filesystem\Filesystem $filesystem
+     *
      * @return $this
      */
     public function setFilesystem(Filesystem $filesystem)
     {
         $this->filesystem = $filesystem;
+
         return $this;
     }
+
 
     /**
      * Get stub template for generated file.
@@ -71,12 +78,9 @@ abstract class Generator
      */
     public function getStub()
     {
-        return (new Stub(
-            __DIR__ . '/Stubs/' . $this->stub . '.stub',
-            $this->getReplacements()
-        )
-        )->render();
+        return (new Stub(__DIR__ . '/Stubs/' . $this->stub . '.stub', $this->getReplacements()))->render();
     }
+
 
     /**
      * Get template replacements.
@@ -86,11 +90,12 @@ abstract class Generator
     public function getReplacements()
     {
         return [
-            'class' => $this->getClass(),
-            'namespace' => $this->getNamespace(),
+            'class'          => $this->getClass(),
+            'namespace'      => $this->getNamespace(),
             'root_namespace' => $this->getRootNamespace()
         ];
     }
+
 
     /**
      * Get base path of destination file.
@@ -102,6 +107,7 @@ abstract class Generator
         return base_path();
     }
 
+
     /**
      * Get destination path for generated file.
      *
@@ -112,6 +118,7 @@ abstract class Generator
         return $this->getBasePath() . '/' . $this->getName() . '.php';
     }
 
+
     /**
      * Get name input.
      *
@@ -120,16 +127,16 @@ abstract class Generator
     public function getName()
     {
         $name = $this->name;
-        if (str_contains($this->name, '\\'))
-        {
+        if (str_contains($this->name, '\\')) {
             $name = str_replace('\\', '/', $this->name);
         }
-        if (str_contains($this->name, '/'))
-        {
+        if (str_contains($this->name, '/')) {
             $name = str_replace('/', '/', $this->name);
         }
+
         return Str::studly(str_replace(' ', '/', ucwords(str_replace('/', ' ', $name))));
     }
+
 
     /**
      * Get class name.
@@ -141,6 +148,7 @@ abstract class Generator
         return Str::studly(class_basename($this->getName()));
     }
 
+
     /**
      * Get paths of namespace.
      *
@@ -150,6 +158,7 @@ abstract class Generator
     {
         return explode('/', $this->getName());
     }
+
 
     /**
      * Get root namespace.
@@ -161,29 +170,34 @@ abstract class Generator
         return config('repository.generator.rootNamespace', $this->getAppNamespace());
     }
 
+
     /**
      * Get class-specific output paths.
      *
      * @param $class
+     *
      * @return string
      */
     public function getConfigGeneratorClassPath($class, $directoryPath = false)
     {
-        switch($class) {
-            case ('models' === $class):
+        switch ($class) {
+            case ( 'models' === $class ):
                 $path = config('repository.generator.paths.models', 'Entities');
                 break;
-            case ('repositories' === $class):
+            case ( 'repositories' === $class ):
                 $path = config('repository.generator.paths.repositories', 'Repositories');
                 break;
-            case ('interfaces' === $class):
+            case ( 'interfaces' === $class ):
                 $path = config('repository.generator.paths.interfaces', 'Repositories');
                 break;
-            case ('presenters' === $class):
+            case ( 'presenters' === $class ):
                 $path = config('repository.generator.paths.presenters', 'Presenters');
                 break;
-            case ('transformers' === $class):
+            case ( 'transformers' === $class ):
                 $path = config('repository.generator.paths.transformers', 'Transformers');
+                break;
+            case ( 'validators' === $class ):
+                $path = config('repository.generator.paths.validators', 'Validators');
                 break;
             default:
                 $path = '';
@@ -196,7 +210,9 @@ abstract class Generator
         return $path;
     }
 
+
     abstract public function getPathConfigNode();
+
 
     /**
      * Get class namespace.
@@ -208,10 +224,14 @@ abstract class Generator
         $segments = $this->getSegments();
         array_pop($segments);
         $rootNamespace = $this->getRootNamespace();
-        if ($rootNamespace == false)
+        if ($rootNamespace == false) {
             return null;
+        }
+
         return 'namespace ' . rtrim($rootNamespace . '\\' . implode($segments, '\\'), '\\') . ';';
     }
+
+
     /**
      * Setup some hook.
      *
@@ -222,6 +242,7 @@ abstract class Generator
         //
     }
 
+
     /**
      * Run the generator.
      *
@@ -231,16 +252,16 @@ abstract class Generator
     public function run()
     {
         $this->setUp();
-        if ($this->filesystem->exists($path = $this->getPath()) && ! $this->force)
-        {
+        if ($this->filesystem->exists($path = $this->getPath()) && ! $this->force) {
             throw new FileAlreadyExistsException($path);
         }
-        if ( ! $this->filesystem->isDirectory($dir = dirname($path)))
-        {
+        if ( ! $this->filesystem->isDirectory($dir = dirname($path))) {
             $this->filesystem->makeDirectory($dir, 0777, true, true);
         }
+
         return $this->filesystem->put($path, $this->getStub());
     }
+
 
     /**
      * Get options.
@@ -252,10 +273,12 @@ abstract class Generator
         return $this->options;
     }
 
+
     /**
      * Determinte whether the given key exist in options array.
      *
      * @param  string $key
+     *
      * @return boolean
      */
     public function hasOption($key)
@@ -263,25 +286,31 @@ abstract class Generator
         return array_key_exists($key, $this->options);
     }
 
+
     /**
      * Get value from options by given key.
      *
-     * @param  string $key
+     * @param  string      $key
      * @param  string|null $default
+     *
      * @return string
      */
     public function getOption($key, $default = null)
     {
-        if ( ! $this->hasOption($key))
+        if ( ! $this->hasOption($key)) {
             return $default;
+        }
+
         return $this->options[$key] ?: $default;
     }
+
 
     /**
      * Helper method for "getOption".
      *
-     * @param  string $key
+     * @param  string      $key
      * @param  string|null $default
+     *
      * @return string
      */
     public function option($key, $default = null)
@@ -289,18 +318,20 @@ abstract class Generator
         return $this->getOption($key, $default);
     }
 
+
     /**
      * Handle call to __get method.
      *
      * @param  string $key
+     *
      * @return string|mixed
      */
     public function __get($key)
     {
-        if (property_exists($this, $key))
-        {
+        if (property_exists($this, $key)) {
             return $this->{$key};
         }
+
         return $this->option($key);
     }
 }

--- a/src/Prettus/Repository/Generators/Migrations/RulesParser.php
+++ b/src/Prettus/Repository/Generators/Migrations/RulesParser.php
@@ -1,0 +1,108 @@
+<?php
+namespace Prettus\Repository\Generators\Migrations;
+
+use Illuminate\Contracts\Support\Arrayable;
+
+/**
+ * Class RulesParser
+ * @package Prettus\Repository\Generators\Migrations
+ */
+class RulesParser implements Arrayable
+{
+
+    /**
+     * The set of rules.
+     *
+     * @var string
+     */
+    protected $rules;
+
+
+    /**
+     * Create new instance.
+     *
+     * @param string|null $rules
+     */
+    public function __construct($rules = null)
+    {
+        $this->rules = $rules;
+    }
+
+
+    /**
+     * Parse a string to array of formatted rules.
+     *
+     * @param  string $rules
+     *
+     * @return array
+     */
+    public function parse($rules)
+    {
+        $this->rules = $rules;
+        $parsed       = [ ];
+        foreach ($this->getRules() as $rulesArray) {
+            $column          = $this->getColumn($rulesArray);
+            $attributes      = $this->getAttributes($column, $rulesArray);
+            $parsed[$column] = $attributes;
+        }
+
+        return $parsed;
+    }
+
+
+    /**
+     * Get array of rules.
+     *
+     * @return array
+     */
+    public function getRules()
+    {
+        if (is_null($this->rules)) {
+            return [ ];
+        }
+
+        return explode(',', str_replace(' ', '', $this->rules));
+    }
+
+
+    /**
+     * Convert string migration to array.
+     *
+     * @return array
+     */
+    public function toArray()
+    {
+        return $this->parse($this->rules);
+    }
+
+
+    /**
+     * Get column name from rules.
+     *
+     * @param  string $rules
+     *
+     * @return string
+     */
+    public function getColumn($rules)
+    {
+        return array_first(explode('=>', $rules), function ($key, $value) {
+            return $value;
+        });
+    }
+
+
+    /**
+     * Get column attributes.
+     *
+     * @param  string $column
+     * @param  string $rules
+     *
+     * @return array
+     */
+    public function getAttributes($column, $rules)
+    {
+
+        return str_replace($column . '=>', '', $rules);
+    }
+
+}

--- a/src/Prettus/Repository/Generators/Stubs/repository/eloquent.stub
+++ b/src/Prettus/Repository/Generators/Stubs/repository/eloquent.stub
@@ -6,6 +6,7 @@ use Prettus\Repository\Eloquent\BaseRepository;
 use Prettus\Repository\Criteria\RequestCriteria;
 use $REPOSITORY$
 use $MODEL$;
+$USE_VALIDATOR$;
 
 /**
  * Class $CLASS$RepositoryEloquent
@@ -22,6 +23,8 @@ class $CLASS$RepositoryEloquent extends BaseRepository implements $CLASS$Reposit
     {
         return $CLASS$::class;
     }
+
+    $VALIDATOR$
 
     /**
      * Boot up the repository, pushing criteria

--- a/src/Prettus/Repository/Generators/Stubs/validator/validator.stub
+++ b/src/Prettus/Repository/Generators/Stubs/validator/validator.stub
@@ -1,0 +1,15 @@
+<?php
+
+$NAMESPACE$
+
+use \Prettus\Validator\Contracts\ValidatorInterface;
+use \Prettus\Validator\LaravelValidator;
+
+class $CLASS$Validator extends LaravelValidator {
+
+    protected $rules = [
+        ValidatorInterface::RULE_CREATE => $RULES$,
+        ValidatorInterface::RULE_UPDATE => $RULES$,
+   ];
+
+}

--- a/src/Prettus/Repository/Generators/ValidatorGenerator.php
+++ b/src/Prettus/Repository/Generators/ValidatorGenerator.php
@@ -1,0 +1,110 @@
+<?php
+namespace Prettus\Repository\Generators;
+
+use Prettus\Repository\Generators\Migrations\RulesParser;
+use Prettus\Repository\Generators\Migrations\SchemaParser;
+
+/**
+ * Class ValidatorGenerator
+ * @package Prettus\Repository\Generators
+ */
+class ValidatorGenerator extends Generator
+{
+
+    /**
+     * Get stub name.
+     *
+     * @var string
+     */
+    protected $stub = 'validator/validator';
+
+
+    /**
+     * Get base path of destination file.
+     *
+     * @return string
+     */
+    public function getBasePath()
+    {
+        return config('repository.generator.basePath', app_path());
+    }
+
+
+    /**
+     * Get root namespace.
+     *
+     * @return string
+     */
+    public function getRootNamespace()
+    {
+        return parent::getRootNamespace() . parent::getConfigGeneratorClassPath($this->getPathConfigNode());
+    }
+
+
+    /**
+     * Get generator path config node.
+     *
+     * @return string
+     */
+    public function getPathConfigNode()
+    {
+        return 'validators';
+    }
+
+
+    /**
+     * Get destination path for generated file.
+     *
+     * @return string
+     */
+    public function getPath()
+    {
+        return $this->getBasePath() . '/' . parent::getConfigGeneratorClassPath($this->getPathConfigNode(),
+            true) . '/' . $this->getName() . 'Validator.php';
+    }
+
+
+    /**
+     * Get array replacements.
+     *
+     * @return array
+     */
+    public function getReplacements()
+    {
+
+        return array_merge(parent::getReplacements(), [
+            'rules' => $this->getRules(),
+        ]);
+    }
+
+
+    /**
+     * Get schema parser.
+     *
+     * @return SchemaParser
+     */
+    public function getSchemaParser()
+    {
+        return new RulesParser($this->rules);
+    }
+
+
+    /**
+     * Get the rules.
+     *
+     * @return string
+     */
+    public function getRules()
+    {
+        if ( ! $this->rules) {
+            return '[]';
+        }
+        $results = '[' . PHP_EOL;
+
+        foreach ($this->getSchemaParser()->toArray() as $column => $value) {
+            $results .= "\t\t'{$column}'\t=>'\t{$value}'," . PHP_EOL;
+        }
+
+        return $results . "\t" . ']';
+    }
+}

--- a/src/Prettus/Repository/Providers/RepositoryServiceProvider.php
+++ b/src/Prettus/Repository/Providers/RepositoryServiceProvider.php
@@ -43,6 +43,7 @@ class RepositoryServiceProvider extends ServiceProvider
         $this->commands('Prettus\Repository\Generators\Commands\TransformerCommand');
         $this->commands('Prettus\Repository\Generators\Commands\PresenterCommand');
         $this->commands('Prettus\Repository\Generators\Commands\EntityCommand');
+        $this->commands('Prettus\Repository\Generators\Commands\ValidatorCommand');
         $this->app->register('Prettus\Repository\Providers\EventServiceProvider');
     }
 

--- a/src/resources/config/repository.php
+++ b/src/resources/config/repository.php
@@ -14,8 +14,8 @@ return [
     |--------------------------------------------------------------------------
     |
     */
-    'pagination'=>[
-        'limit'=>15
+    'pagination' => [
+        'limit' => 15
     ],
 
     /*
@@ -30,9 +30,9 @@ return [
     JsonApiSerializer
 
     */
-    'fractal'=>[
-        'params'=>[
-            'include'=>'include'
+    'fractal'    => [
+        'params'     => [
+            'include' => 'include'
         ],
         'serializer' => League\Fractal\Serializer\DataArraySerializer::class
     ],
@@ -43,7 +43,7 @@ return [
     |--------------------------------------------------------------------------
     |
     */
-    'cache'=>[
+    'cache'      => [
         /*
          |--------------------------------------------------------------------------
          | Cache Status
@@ -52,7 +52,7 @@ return [
          | Enable or disable cache
          |
          */
-        'enabled'   => true,
+        'enabled'    => true,
 
         /*
          |--------------------------------------------------------------------------
@@ -62,17 +62,17 @@ return [
          | Time of expiration cache
          |
          */
-        'minutes'   => 30,
+        'minutes'    => 30,
 
-         /*
-          |--------------------------------------------------------------------------
-          | Cache Repository
-          |--------------------------------------------------------------------------
-          |
-          | Instance of Illuminate\Contracts\Cache\Repository
-          |
-          */
-        'repository'=> 'cache',
+        /*
+         |--------------------------------------------------------------------------
+         | Cache Repository
+         |--------------------------------------------------------------------------
+         |
+         | Instance of Illuminate\Contracts\Cache\Repository
+         |
+         */
+        'repository' => 'cache',
 
         /*
           |--------------------------------------------------------------------------
@@ -82,7 +82,7 @@ return [
           |
           |
           */
-        'clean'     => [
+        'clean'      => [
 
             /*
               |--------------------------------------------------------------------------
@@ -102,24 +102,24 @@ return [
               | delete : Clear Cache on delete Entry in repository
               |
               */
-            'on' => [
-                'create'=>true,
-                'update'=>true,
-                'delete'=>true,
+            'on'      => [
+                'create' => true,
+                'update' => true,
+                'delete' => true,
             ]
         ],
 
-        'params'    => [
-              /*
-              |--------------------------------------------------------------------------
-              | Skip Cache Params
-              |--------------------------------------------------------------------------
-              |
-              |
-              | Ex: http://prettus.local/?search=lorem&skipCache=true
-              |
-              */
-            'skipCache'=>'skipCache'
+        'params'  => [
+            /*
+            |--------------------------------------------------------------------------
+            | Skip Cache Params
+            |--------------------------------------------------------------------------
+            |
+            |
+            | Ex: http://prettus.local/?search=lorem&skipCache=true
+            |
+            */
+            'skipCache' => 'skipCache'
         ],
 
         /*
@@ -137,9 +137,9 @@ return [
        |
        | 'except'  =>['find'],
        */
-        'allowed'=>[
-            'only'  =>null,
-            'except'=>null
+        'allowed' => [
+            'only'   => null,
+            'except' => null
         ]
     ],
 
@@ -151,7 +151,7 @@ return [
     | Settings of request parameters names that will be used by Criteria
     |
     */
-    'criteria'=>[
+    'criteria'   => [
         /*
         |--------------------------------------------------------------------------
         | Accepted Conditions
@@ -167,7 +167,7 @@ return [
         | $query->where('foo','like','bar')
         |
         */
-        'acceptedConditions'=>[
+        'acceptedConditions' => [
             '=','like'
         ],
         /*
@@ -202,13 +202,13 @@ return [
         |   http://prettus.local/?search=lorem&orderBy=id&sortedBy=desc
         |
         */
-        'params'=>[
-            'search'        =>'search',
-            'searchFields'  =>'searchFields',
-            'filter'        =>'filter',
-            'orderBy'       =>'orderBy',
-            'sortedBy'      =>'sortedBy',
-            'with'          =>'with'
+        'params'             => [
+            'search'       => 'search',
+            'searchFields' => 'searchFields',
+            'filter'       => 'filter',
+            'orderBy'      => 'orderBy',
+            'sortedBy'     => 'sortedBy',
+            'with'         => 'with'
         ]
     ],
     /*
@@ -217,15 +217,16 @@ return [
     |--------------------------------------------------------------------------
     |
     */
-    'generator'=>[
-        'basePath'=>app_path(),
-        'rootNamespace'=>'App\\',
-        'paths'=>[
-            'models'=>'Entities',
-            'repositories'=>'Repositories',
-            'interfaces'=>'Repositories',
-            'transformers'=>'Transformers',
-            'presenters'=>'Presenters'
+    'generator'  => [
+        'basePath'      => app_path(),
+        'rootNamespace' => 'App\\',
+        'paths'         => [
+            'models'       => 'Entities',
+            'repositories' => 'Repositories',
+            'interfaces'   => 'Repositories',
+            'transformers' => 'Transformers',
+            'presenters'   => 'Presenters',
+            'validators'   => 'Validators',
         ]
     ]
 ];


### PR DESCRIPTION
There are multiple ways to generate a validator class:

    $ art make:validator Dog --rules="name=>required, age=>required|numeric, email=>sometimes|email"

or

    $ art make:entity Dog --rules="name=>required, age=>required|numeric, email=>sometimes|email" --fillable="name:string, age:integer, email:string" --validator=yes

or

    $ art make:entity Dog --rules="name=>required, age=>required|numeric, email=>sometimes|email" --fillable="name:string, age:integer, email:string"

For the last command you will get a confirm box that asks you if you want a validator or not.

If the validator is created it will be attached to the repository using the `validator()` method.